### PR TITLE
Changed load structure of the NotORM_Cache_Include

### DIFF
--- a/NotORM/Cache.php
+++ b/NotORM/Cache.php
@@ -75,7 +75,9 @@ class NotORM_Cache_Include implements NotORM_Cache {
 	
 	function __construct($filename) {
 		$this->filename = $filename;
-		$this->data = @include realpath($filename); // @ - file may not exist, realpath() to not include from include_path //! silently falls with syntax error and fails with unreadable file
+		$filePath = realpath($filename);
+		$this->data = is_file($filePath) ? include $filePath : array();
+
 		if (!is_array($this->data)) { // empty file returns 1
 			$this->data = array();
 		}


### PR DESCRIPTION
Now the use of the silent-operator (@) is not needed anymore.
This is an improvement because of several reasons:
• Scripts fail, if xdebug.scream = 1, because the warning is nevertheless shown, even if the @-operator is used
• The code is more readable and cleaner
• The silent operator has a performance drawback (even if this is not the most important issue here)
