### PR TITLE
Fetch only one column

### DIFF
--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -593,10 +593,11 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	/** Fetch next row of result
 	* @return NotORM_Row or false if there is no row
 	*/
-	function fetch() {
+	function fetch($key = '') {
 		$this->execute();
 		$return = current($this->data);
 		next($this->data);
+		if ($key) return $return[$key];
 		return $return;
 	}
 	


### PR DESCRIPTION
Sometimes I need fetch only one column from one row but not by primary_id. e.g.:

```
$row = $notorm->application('title', $title)->fetch();
echo $row['web'];
```

this simple pull request is shortcut for this situation:

```
echo $notorm->application('title', $title)->fetch('web');
```
