### PR TITLE
Fix: Don't change $this->offset from null to 0

### DIFF
--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -457,10 +457,14 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		$this->rows = null;
 		if ($this->union) {
 			$this->unionLimit = +$limit;
-			$this->unionOffset = +$offset;
+			if (isset($offset)) {
+				$this->unionOffset = +$offset;
+			}
 		} else {
 			$this->limit = +$limit;
-			$this->offset = +$offset;
+			if (isset($offset)) {
+				$this->offset = +$offset;
+			}
 		}
 		return $this;
 	}


### PR DESCRIPTION
Fix: Don't change $this->offset from null to 0 when no $offset is specified.
Having zero in $this->offset triggers adding OFFSET to the query causing $table->limit(1)->update(...) to fail.
