### PR TITLE
fix fetchPairs() to work with referenced tables

### DIFF
--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -634,8 +634,8 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 			$clone->select = array("$key, $this->table.*");
 		}
 		foreach ($clone as $row) {
-			$values = array_values(iterator_to_array($row));
-			$return[$values[0]] = ($value != "" ? $values[(isset($values[1]) ? 1 : 0)] : $row); // isset($values[1]) - fetchPairs("id", "id")
+			$values = iterator_to_array($row);
+			$return[ $values[$key] ] = ($value != "" ? $values[$value] : $row);
 		}
 		return $return;
 	}


### PR DESCRIPTION
Take this query as an example:
$notorm->course[92]->hole('deleted', null)->order('rank')->fetchPairs('rank', 'rank');

It generates the following SQL:
SELECT holes.course, rank, rank 
FROM holes 
WHERE (holes.course IN (92)) AND (deleted IS NULL) 
ORDER BY holes.course, rank

The query itself is all right but fetchPairs() in your implementation returned
array('92' => '18')
instead of 
array('1'=>'1', '2'=>'2', ..., '18' => '18');

The culprit was that fetchPairs used $values[0] as key which in this case was the course id. And I couldn't remove course id from the first position in results.

I suggest to make fetchPairs() use $key/$value directly (instead of numerical indexes).
