### PR TITLE
One liner for simple fetch as associative array

### DIFF
--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -640,6 +640,14 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		return $return;
 	}
 	
+	/**
+	 * One liner for simple fetch as associative array
+	 * @return array
+	 */
+	function fetchAssoc() {
+		return array_map('iterator_to_array', iterator_to_array($this));
+	}
+	
 	protected function access($key, $delete = false) {
 		if ($delete) {
 			if (is_array($this->access)) {


### PR DESCRIPTION
A useful method for creating APIs when you need to use json_encode on database results, this would facilitate the process. One could simply call `json_encode($result->fetchAssoc())` instead of building the array by hand.
