### PR TITLE
Fix update row

### DIFF
--- a/NotORM/Row.php
+++ b/NotORM/Row.php
@@ -98,6 +98,10 @@ class NotORM_Row extends NotORM_Abstract implements IteratorAggregate, ArrayAcce
 		// update is an SQL keyword
 		if (!isset($data)) {
 			$data = $this->modified;
+		} else {
+			foreach ($data as $key => $value) {
+				$this->offsetSet($key, $value);
+			}
 		}
 		$result = new NotORM_Result($this->result->table, $this->result->notORM);
 		return $result->where($this->result->primary, $this[$this->result->primary])->update($data);

--- a/tests/33-update-row.phpt
+++ b/tests/33-update-row.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Update db and also row
+--FILE--
+<?php
+include_once dirname(__FILE__) . "/connect.inc.php";
+
+$application = $software->application[1];
+$data = array("title" => "Adminer2");
+$application->update($data);
+
+echo "$application[title]\n";
+
+$data = array("title" => "Adminer");
+$application->update($data);
+
+echo "$application[title]\n";
+?>
+--EXPECTF--
+Adminer2
+Adminer


### PR DESCRIPTION
1. This update db and also `$application`

``` php
$application = $software->application[1];
$application["title"] = "Adminer2";
$application->update();
echo $application["title"] // return Adminer2
```
1. This update only db but **not** `$application`

``` php
$application = $software->application[1];
$data = array("title" => "Adminer2");
$application->update($data);
echo $application["title"] // return Adminer 
```

Second is not consistent and unexpected behavior. This pull request fix second way. I added also test for it.
