### PR TITLE
Possibility turn off associative array for NotORM_Result

### DIFF
--- a/NotORM.php
+++ b/NotORM.php
@@ -30,6 +30,7 @@ abstract class NotORM_Abstract {
 	protected $debug = false;
 	protected $freeze = false;
 	protected $rowClass = 'NotORM_Row';
+	protected $assocArray = true;
 	
 	protected function access($key, $delete = false) {
 	}
@@ -42,6 +43,7 @@ abstract class NotORM_Abstract {
 * @property-write mixed $debug = false Enable debugging queries, true for fwrite(STDERR, $query), callback($query, $parameters) otherwise
 * @property-write bool $freeze = false Disable persistence
 * @property-write string $rowClass = 'NotORM_Row' Class used for created objects
+* @property-write bool $assocArray = true Disable associative array for 'NotORM_Result' (useful for json)
 * @property-write string $transaction Assign 'BEGIN', 'COMMIT' or 'ROLLBACK' to start or stop transaction
 */
 class NotORM extends NotORM_Abstract {
@@ -73,7 +75,7 @@ class NotORM extends NotORM_Abstract {
 	* @return null
 	*/
 	function __set($name, $value) {
-		if ($name == "debug" || $name == "freeze" || $name == "rowClass") {
+		if ($name == "debug" || $name == "freeze" || $name == "rowClass" || $name == "assocArray") {
 			$this->$name = $value;
 		}
 		if ($name == "transaction") {

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -600,7 +600,11 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 							$this->access[$this->primary] = true;
 						}
 					}
-					$this->rows[$key] = new $this->notORM->rowClass($row, $this);
+					if ($this->notORM->assocArray) {
+						$this->rows[$key] = new $this->notORM->rowClass($row, $this);
+					} else {
+						$this->rows[]     = new $this->notORM->rowClass($row, $this);
+					}
 				}
 			}
 			$this->data = $this->rows;

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -600,10 +600,11 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 							$this->access[$this->primary] = true;
 						}
 					}
+					$rowClass = new $this->notORM->rowClass($row, $this);
 					if ($this->notORM->assocArray) {
-						$this->rows[$key] = new $this->notORM->rowClass($row, $this);
+						$this->rows[$key] = $rowClass;
 					} else {
-						$this->rows[]     = new $this->notORM->rowClass($row, $this);
+						$this->rows[]     = $rowClass;
 					}
 				}
 			}


### PR DESCRIPTION
`json_encode($notorm->application())` return:

```
{
    "1":{"id": "1", ....},
    "2":{"id": "2", ....}
}
```

and with `$notorm->assocArray = false` return:

```
[
    {"id": "1", ....},
    {"id": "2", ....}
]
```

this is more useful for building rest api application.
