### PR TITLE
Fix quote function to correctly interpret NULL values (insert, update)

### DIFF
--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -170,7 +170,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	}
 	
 	protected function quote($val) {
-		if (!isset($val)) {
+		if (!isset($val) || $val == NULL) {
 			return "NULL";
 		}
 		if (is_array($val)) { // (a, b) IN ((1, 2), (3, 4))


### PR DESCRIPTION
When inserting an array of datas which have some keys not set to a value, the quote function intepret it as '' instead of NULL. And when the target field is an integer in db, the result stored is 0
