### PR TITLE
[fix] stderr replaced with error_log call

### DIFF
--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -150,7 +150,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 						break;
 					}
 				}
-				fwrite(STDERR, "$backtrace[file]:$backtrace[line]:$debug\n");
+				error_log("$backtrace[file]:$backtrace[line]:$debug\n", 0);
 			} elseif (call_user_func($this->notORM->debug, $query, $parameters) === false) {
 				return false;
 			}


### PR DESCRIPTION
The current code uses stderr for logging, which is fine for PHP in CLI mode.
When PHP works as web-server module, stderr is not defined.
error_log works the same as stderr in CLI and web-server mode. 
