### PR TITLE
[add] jsonAsArray flag, to enable json serialization as plain data array

### DIFF
--- a/NotORM.php
+++ b/NotORM.php
@@ -30,6 +30,7 @@ abstract class NotORM_Abstract {
 	protected $debug = false;
 	protected $freeze = false;
 	protected $rowClass = 'NotORM_Row';
+	protected $jsonAsArray = false;
 	
 	protected function access($key, $delete = false) {
 	}
@@ -73,7 +74,7 @@ class NotORM extends NotORM_Abstract {
 	* @return null
 	*/
 	function __set($name, $value) {
-		if ($name == "debug" || $name == "freeze" || $name == "rowClass") {
+		if ($name == "debug" || $name == "freeze" || $name == "rowClass" || $name == "jsonAsArray") {
 			$this->$name = $value;
 		}
 		if ($name == "transaction") {

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -788,7 +788,10 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	
 	function jsonSerialize() {
 		$this->execute();
-		return $this->data;
+		if ($this->notORM->jsonAsArray)
+			return array_values($this->data);
+		else
+			return $this->data;
 	}
 	
 }


### PR DESCRIPTION
Adds option to serialize data to json as plain array
Similar to #61, but do not mess with internal data structures and affects only json serialization

Changes do not affect the default behavior, but as far as I can see, the json is mostly purposed for client-server communications, and majority of client side libraries expect to receive an array of data not a map, so it may have sense to serialize data as json array by default. 
