### PR TITLE
Add another method to do insert/update on duplicate called admit()

### DIFF
--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -301,7 +301,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 				return $return;
 			} catch (PDOException $e) {
 				$connection->setAttribute(PDO::ATTR_ERRMODE, $errorMode);
-				if ($e->getCode() == "23000") { // "23000" - duplicate key
+				if ($e->getCode() == "23000" || $e->getCode() == "23505") { // "23000" - duplicate key, "23505" unique constraint pgsql
 					if (!$update) {
 						return 0;
 					}

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -317,6 +317,31 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 			}
 		}
 	}
+
+	/** Insert row or update if it already exists
+	* @param array ($column => $value)
+	* @param array ($column => $value)
+	* @param array ($column => $value), empty array means use $insert
+	* @return NotORM_Row or false in case of an error
+	*/
+	function admit(array $unique, array $insert, array $update = array())
+	{
+		if (!$update) {
+			$update = $insert;
+		}
+		$insert = $unique + $insert;
+		$row = $this->where($unique)->fetch();
+		if ( ! $row) {
+			$row = $this->insert($insert);
+		}
+		else {
+			$affected = $this->update($update);
+			if ( ! $affected) {
+				$row = $affected;
+			}
+		}
+		return $row;
+	}
 	
 	/** Delete all rows in result set
 	* @return int number of affected rows or false in case of an error

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -349,15 +349,14 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		$insert = $unique + $insert;
 		$row = $this->where($unique)->fetch();
 		if ( ! $row) {
-			$row = $this->insert($insert);
+			return $this->insert($insert);
 		}
 		else {
-			$affected = $this->update($update);
-			if ( ! $affected) {
-				$row = $affected;
+			foreach ($update as $field => $value) {
+				$row[$field] = $value;
 			}
+			return $row->update() ? $row : false;
 		}
-		return $row;
 	}
 	
 	/** Get last insert ID

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -351,12 +351,13 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		if ( ! $row) {
 			return $this->insert($insert);
 		}
-		else {
+		else if ($update) {
 			foreach ($update as $field => $value) {
 				$row[$field] = $value;
 			}
 			return $row->update() ? $row : false;
 		}
+		return $row;
 	}
 	
 	/** Get last insert ID

--- a/tests/34-admit.phpt
+++ b/tests/34-admit.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Admit
+--FILE--
+<?php
+include_once dirname(__FILE__) . "/connect.inc.php";
+
+for ($i=0; $i < 2; $i++) {
+	$application = $software->application()->admit(array("id" => 5), array("author_id" => 12, "title" => "Texy", "web" => "", "slogan" => "$i"));
+	echo "{$application['id']},{$application['slogan']}\n";
+}
+$application = $software->application[5];
+$application_tag = $application->application_tag()->admit(array("tag_id" => 21), array());
+echo "{$application_tag['tag_id']},{$application_tag['application_id']}\n";
+$software->application("id", 5)->delete();
+?>
+--EXPECTF--
+5,0
+5,1
+21,5


### PR DESCRIPTION
I have 2 reasons behind this change, and maybe there is another way, but I couldn't find a better solution.
1. insert_update() within a transaction in postgres doesn't work.  Reason is that postgresql will automatically kill the transaction as soon as there is an error, even if there is code to catch it :(
2. I was constantly fetching the row that was updated() after calling insert_update() because update() doesn't return the row after it was updated.

An example is adding a unique tag, that you then want to add to an affiliation table:

```
$tag = $this->db->tags()->admit(array('tag' => $cleaned_tag));
$this->db->packages_tags()->admit(array(
    'package_id' => $this->package['id'],
    'tag_id'     => $tag['id']
));
```

Let me know what you think ... NotORM is so amazing, thank you
