### PR TITLE
Throw exception on multiple occuring primary keys.

### DIFF
--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -644,6 +644,10 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 							$this->access[$this->primary] = true;
 						}
 					}
+                                        if(isset($this->rows[$key]))
+                                        {
+                                            throw new Exception('The primary key of the selected table occurs more than one time in the rows. Join differently so that this does not happen!');
+                                        }
 					$this->rows[$key] = new $this->notORM->rowClass($row, $this);
 				}
 			}


### PR DESCRIPTION
This way the programmer cannot make a mistake. I wondered where all my rows gone because I joined from the table which had the primary key listed multiple times in the resultset.
Maybe this is not a very elegent way to do it, but what do you think of it? 
