### PR TITLE
empty insert for SQLite driver

### DIFF
--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -225,7 +225,11 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 				}
 			}
 			//! driver specific empty $data and extended insert
-			$insert = "(" . implode(", ", array_keys($data)) . ") VALUES " . implode(", ", $values);
+			$keys = array_keys($data);
+			if (sizeof($keys) || $this->notORM->driver != "sqlite")
+				$insert = "(" . implode(", ", $keys) . ") VALUES " . implode(", ", $values);
+			else
+				$insert = "DEFAULT VALUES";
 		}
 		// requires empty $this->parameters
 		$return = $this->query("INSERT INTO $this->table $insert", $parameters);


### PR DESCRIPTION
Currently for empty inserts NotORM generates something like 
`Insert into table() values()`

That is fine for MySQL but doesn't work for SQLite, Patch adds SQLite specific solution for this case.

The same syntax as for sqlite will work for mssql and postgresql drivers as well. As don't have those DBs locally, and can't check is original syntax fails for them, so update includes only sqlite driver. 
