### PR TITLE
modified for errors preventing, and data correcting.

### DIFF
--- a/NotORM.php
+++ b/NotORM.php
@@ -62,13 +62,32 @@ class NotORM extends NotORM_Abstract {
 		}
 		$this->structure = $structure;
 		$this->cache = $cache;
+
+    $this->load_tables();
 	}
+
+  protected $tables = array();
+  protected function load_tables() {
+    $table_prefix = $this->structure->getPrefix();
+    $table_prefix_len = strlen($table_prefix);
+
+    $st = $this->connection->query("show tables;");
+    while($table = $st->fetchColumn()) {
+      if ( strpos($table, $table_prefix) !== 0 )
+        continue;
+      $this->tables[] = substr($table, $table_prefix_len);
+    }
+  }
 	
 	/** Get table data to use as $db->table[1]
 	* @param string
 	* @return NotORM_Result
 	*/
 	function __get($table) {
+    if( !in_array($table, $this->tables) ){
+      throw new ErrorException("There is no table named " . $table);
+    }
+
 		return new NotORM_Result($this->structure->getReferencingTable($table, ''), $this, true);
 	}
 	

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -25,16 +25,34 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
     $this->load_columns();
 	}
 
-  protected $columns = array();
-  protected function load_columns() {
-    $st = $this->notORM->connection->query("show columns from `$this->table`;");
+  public static function s_columns($table, $conn = null) {
+    static $columns = array();
+    if( array_key_exists($table, $columns) )
+      return $columns[$table];
+
+    if(!$conn)
+      return array();
+
+    $columns[$table] = array();
+    $st = $conn->query("show columns from `$table`;");
     foreach( $st as $row ) {
       $row = array_change_key_case($row);
-      $this->columns[] = $row['field'];
+      $columns[$table][] = $row['field'];
     }
+    return $columns[$table];
+  }
+
+  public function columns() {
+    return $this->columns;
+  }
+
+  protected $columns;
+  protected function load_columns() {
+    $this->columns = static::s_columns($this->table, $this->notORM->connection);
   }
 
   protected function filter_data( array $data) {
+
     foreach ($data as $key => $_) {
       if( !in_array($key, $this->columns) )
         unset($data[$key]);

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -21,7 +21,38 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		$this->notORM = $notORM;
 		$this->single = $single;
 		$this->primary = $notORM->structure->getPrimary($table);
+
+    $this->load_columns();
 	}
+
+  protected $columns = array();
+  protected function load_columns() {
+    $st = $this->notORM->connection->query("show columns from `$this->table`;");
+    foreach( $st as $row ) {
+      $row = array_change_key_case($row);
+      $this->columns[] = $row['field'];
+    }
+  }
+
+  protected function filter_data( array $data) {
+    foreach ($data as $key => $_) {
+      if( !in_array($key, $this->columns) )
+        unset($data[$key]);
+    }
+
+    return $data;
+  }
+
+  public static function db_quote( $key ) {
+    if( is_string($key) )
+      return "`{$key}`";
+
+    foreach ($key as &$k) {
+      $k = static::db_quote($k);
+    }
+
+    return $key;
+  }
 	
 	/** Save data to cache and empty result
 	*/
@@ -99,7 +130,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 					$table = $this->notORM->structure->getReferencedTable($name, $parent);
 					$column = ($delimiter == ':' ? $this->notORM->structure->getPrimary($parent) : $this->notORM->structure->getReferencedColumn($name, $parent));
 					$primary = ($delimiter == ':' ? $this->notORM->structure->getReferencedColumn($parent, $table) : $this->notORM->structure->getPrimary($table));
-					$return[$name] = " LEFT JOIN $table" . ($table != $name ? " AS $name" : "") . " ON $parent.$column = $name.$primary"; // should use alias if the table is used on more places
+					$return[$name] = " LEFT JOIN " . static::db_quote($table) . ($table != $name ? " AS $name" : "") . " ON $parent.$column = $name.$primary"; // should use alias if the table is used on more places
 					$parent = $name;
 				}
 			}
@@ -124,7 +155,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		} else {
 			$return .= ($join ? "$this->table." : "") . "*";
 		}
-		$return .= " FROM $this->table" . implode($join) . $this->whereString();
+		$return .= " FROM " . static::db_quote($this->table) . implode($join) . $this->whereString();
 		if ($this->union) {
 			$return = ($this->notORM->driver == "sqlite" || $this->notORM->driver == "oci" ? $return : "($return)") . implode($this->union);
 			if ($this->unionOrder) {
@@ -206,6 +237,11 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		if (!$rows) {
 			return 0;
 		}
+
+    foreach($rows as &$_) {
+      $_ = $this->filter_data($_);
+    }
+
 		$data = reset($rows);
 		$parameters = array();
 		if ($data instanceof NotORM_Result) {
@@ -230,12 +266,12 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 			}
 			//! driver specific extended insert
 			$insert = ($data || $this->notORM->driver == "mysql"
-				? "(" . implode(", ", array_keys($data)) . ") VALUES " . implode(", ", $values)
+				? "(" . implode(", ", static::db_quote(array_keys($data))) . ") VALUES " . implode(", ", $values)
 				: "DEFAULT VALUES"
 			);
 		}
 		// requires empty $this->parameters
-		$return = $this->query("INSERT INTO $this->table $insert", $parameters);
+		$return = $this->query("INSERT INTO " . static::db_quote($this->table) . " $insert", $parameters);
 		if (!$return) {
 			return false;
 		}
@@ -271,6 +307,8 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		if ($this->notORM->freeze) {
 			return false;
 		}
+
+    $data = $this->filter_data( $data );
 		if (!$data) {
 			return 0;
 		}
@@ -278,7 +316,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		$parameters = array();
 		foreach ($data as $key => $val) {
 			// doesn't use binding because $this->parameters can be filled by ? or :name
-			$values[] = "$key = " . $this->quote($val);
+			$values[] = static::db_quote($key) . " = " . $this->quote($val);
 			if ($val instanceof NotORM_Literal && $val->parameters) {
 				$parameters = array_merge($parameters, $val->parameters);
 			}
@@ -287,7 +325,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 			$parameters = array_merge($parameters, $this->parameters);
 		}
 		// joins in UPDATE are supported only in MySQL
-		$return = $this->query("UPDATE" . $this->topString($this->limit, $this->offset) . " $this->table SET " . implode(", ", $values) . $this->whereString(), $parameters);
+		$return = $this->query("UPDATE" . $this->topString($this->limit, $this->offset) . " " . static::db_quote($this->table) . " SET " . implode(", ", $values) . $this->whereString(), $parameters);
 		if (!$return) {
 			return false;
 		}
@@ -301,11 +339,16 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	* @return int number of affected rows or false in case of an error
 	*/
 	function insert_update(array $unique, array $insert, array $update = array()) {
-		if (!$update) {
-			$update = $insert;
-		}
-		$insert = $unique + $insert;
-		$values = "(" . implode(", ", array_keys($insert)) . ") VALUES " . $this->quote($insert);
+    $unique = $this->filter_data( $unique );
+    $insert = $this->filter_data( $insert );
+    $update = $this->filter_data( $update );
+
+    if (!$update) {
+      $update = $insert;
+    }
+    $insert = $unique + $insert;
+
+		$values = "(" . implode(", ", static::db_quote(array_keys($insert))) . ") VALUES " . $this->quote($insert);
 		//! parameters
 		if ($this->notORM->driver == "mysql") {
 			$set = array();
@@ -313,7 +356,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 				$update = $unique;
 			}
 			foreach ($update as $key => $val) {
-				$set[] = "$key = " . $this->quote($val);
+				$set[] = static::db_quote($key) . " = " . $this->quote($val);
 				//! parameters
 			}
 			return $this->insert("$values ON DUPLICATE KEY UPDATE " . implode(", ", $set));
@@ -358,7 +401,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		if ($this->notORM->freeze) {
 			return false;
 		}
-		$return = $this->query("DELETE" . $this->topString($this->limit, $this->offset) . " FROM $this->table" . $this->whereString(), $this->parameters);
+		$return = $this->query("DELETE" . $this->topString($this->limit, $this->offset) . " FROM " . static::db_quote($this->table) . $this->whereString(), $this->parameters);
 		if (!$return) {
 			return false;
 		}
@@ -395,6 +438,9 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	
 	protected function whereOperator($operator, array $args) {
 		$condition = $args[0];
+    if( in_array($condition, $this->columns) )
+      $condition = static::db_quote( $condition );
+
 		$parameters = (count($args) > 1 ? $args[1] : array());
 		if (is_array($condition)) { // where(array("column1" => 1, "column2 > ?" => 2))
 			foreach ($condition as $key => $val) {
@@ -574,7 +620,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	*/
 	function aggregation($function) {
 		$join = $this->createJoins(implode(",", $this->conditions) . ",$function");
-		$query = "SELECT $function FROM $this->table" . implode($join);
+		$query = sprintf("SELECT $function FROM %s %s", static::db_quote($this->table), implode($join));
 		if ($this->where) {
 			$query .= " WHERE " . implode($this->where);
 		}
@@ -688,11 +734,11 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		$clone = clone $this;
 		if ($value != "") {
 			$clone->select = array();
-			$clone->select("$key, $value"); // MultiResult adds its column
+			$clone->select(sprintf("%s, %s", static::db_quote($key), static::db_quote($value))); // MultiResult adds its column
 		} elseif ($clone->select) {
 			array_unshift($clone->select, $key);
 		} else {
-			$clone->select = array("$key, $this->table.*");
+			$clone->select = array(sprintf("%s, %s.*", static::db_quote($key), static::db_quote($this->table)));
 		}
 		foreach ($clone as $row) {
 			$values = array_values(iterator_to_array($row));

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -159,6 +159,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		}
 		$return = $this->notORM->connection->prepare($query);
 		if (!$return || !$return->execute(array_map(array($this, 'formatValue'), $parameters))) {
+      $this->notORM->debug && error_log( json_encode($return->errorInfo()) );
 			$return = false;
 		}
 		if ($this->notORM->debugTimer) {

--- a/NotORM/Structure.php
+++ b/NotORM/Structure.php
@@ -65,6 +65,10 @@ class NotORM_Structure_Convention implements NotORM_Structure {
 		$this->table = $table;
 		$this->prefix = $prefix;
 	}
+
+  function getPrefix() {
+    return $this->prefix;
+  }
 	
 	function getPrimary($table) {
 		return sprintf($this->primary, $this->getColumnFromTable($table));


### PR DESCRIPTION
after using such NotORM_Literal("now()"), we hope to get the actual values persistent.  So I reload the row data after using NotORM_Literal. 

when we do  table->insert($data) or table->save($data), if we got some wrong keys which are in table in $data, we will get statement error. For preventing this, I create a function to filter them.

Last, I often write a wrong table name, but NotORM execute normally and return null. It's hard to debug because I don't know which error took place, wrong table name or no record(s) returned.

OK. That's all.
