### PR TITLE
added ->join method

### DIFF
--- a/NotORM/MultiResult.php
+++ b/NotORM/MultiResult.php
@@ -101,7 +101,7 @@ class NotORM_MultiResult extends NotORM_Result {
 		}
 	}
 	
-	function count($column = "") {
+	function count($column = ""):int {
 		$return = parent::count($column);
 		return (isset($return) ? $return : 0);
 	}

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -396,7 +396,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		$args = func_get_args();
 		return $this->whereOperator("AND", $args);
 	}
-	
+
 	function join($table,$on=false,$outer=false) {
 		$tbl=preg_replace('/^[^a-z]*((?:.* as )?`?([a-z][a-z0-9\_]*)).*$/i','$2',$table);
 		$this->join[$tbl]=" LEFT ".($outer?"OUTER ":"")."JOIN ".$table." ".($on===false?"":" ON ".$on);

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -6,7 +6,7 @@
 */
 class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Countable, JsonSerializable {
 	protected $single;
-	protected $select = array(), $conditions = array(), $where = array(), $parameters = array(), $order = array(), $limit = null, $offset = null, $group = "", $having = "", $lock = null;
+	protected $select = array(), $conditions = array(), $where = array(), $parameters = array(), $order = array(), $limit = null, $offset = null, $group = "", $having = "", $lock = null, $join = array();
 	protected $union = array(), $unionOrder = array(), $unionLimit = null, $unionOffset = null;
 	protected $data, $referencing = array(), $aggregation = array(), $accessed, $access, $keys = array();
 	
@@ -102,6 +102,11 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 					$return[$name] = " LEFT JOIN $table" . ($table != $name ? " AS $name" : "") . " ON $parent.$column = $name.$primary"; // should use alias if the table is used on more places
 					$parent = $name;
 				}
+			}
+		}
+		if(count($this->join)) {
+			foreach ($this->join as $tableAlias => $joinStartament) {
+				$return[$tableAlias]=$joinStartament;
 			}
 		}
 		return $return;
@@ -390,6 +395,13 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	function where($condition, $parameters = array()) {
 		$args = func_get_args();
 		return $this->whereOperator("AND", $args);
+	}
+	
+	function join($table,$on=false,$outer=false) {
+		$tbl=preg_replace('/^[^a-z]*((?:.* as )?`?([a-z][a-z0-9\_]*)).*$/i','$2',$table);
+		$this->join[$tbl]=" LEFT ".($outer?"OUTER ":"")."JOIN ".$table." ".($on===false?"":" ON ".$on);
+	
+		return $this;
 	}
 	
 	protected function whereOperator($operator, array $args) {

--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -396,7 +396,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 		$args = func_get_args();
 		return $this->whereOperator("AND", $args);
 	}
-
+	
 	function join($table,$on=false,$outer=false) {
 		$tbl=preg_replace('/^[^a-z]*((?:.* as )?`?([a-z][a-z0-9\_]*)).*$/i','$2',$table);
 		$this->join[$tbl]=" LEFT ".($outer?"OUTER ":"")."JOIN ".$table." ".($on===false?"":" ON ".$on);
@@ -599,7 +599,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	* @param string
 	* @return int
 	*/
-	function count($column = "") {
+	function count($column = ""): int {
 		if (!$column) {
 			$this->execute();
 			return count($this->data);
@@ -611,7 +611,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	* @param string
 	* @return int
 	*/
-	function min($column) {
+	function min($column):int {
 		return $this->aggregation("MIN($column)");
 	}
 	
@@ -619,7 +619,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	* @param string
 	* @return int
 	*/
-	function max($column) {
+	function max($column):int {
 		return $this->aggregation("MAX($column)");
 	}
 	
@@ -627,7 +627,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	* @param string
 	* @return int
 	*/
-	function sum($column) {
+	function sum($column):int {
 		return $this->aggregation("SUM($column)");
 	}
 	
@@ -741,27 +741,27 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	
 	// Iterator implementation (not IteratorAggregate because $this->data can be changed during iteration)
 	
-	function rewind() {
+	function rewind():void {
 		$this->execute();
 		$this->keys = array_keys($this->data);
 		reset($this->keys);
 	}
 	
 	/** @return NotORM_Row */
-	function current() {
+	function current():NotORM_Row {
 		return $this->data[current($this->keys)];
 	}
 	
 	/** @return string row ID */
-	function key() {
+	function key(): string {
 		return current($this->keys);
 	}
 	
-	function next() {
+	function next(): void {
 		next($this->keys);
 	}
 	
-	function valid() {
+	function valid(): bool {
 		return current($this->keys) !== false;
 	}
 	
@@ -771,7 +771,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	* @param string row ID or array for where conditions
 	* @return bool
 	*/
-	function offsetExists($key) {
+	function offsetExists($key): bool {
 		$row = $this->offsetGet($key);
 		return isset($row);
 	}
@@ -780,7 +780,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	* @param string row ID or array for where conditions
 	* @return NotORM_Row or null if there is no such row
 	*/
-	function offsetGet($key) {
+	function offsetGet($key):NotORM_Row|null {
 		if ($this->single && !isset($this->data)) {
 			$clone = clone $this;
 			if (is_array($key)) {
@@ -814,7 +814,7 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	* @param NotORM_Row
 	* @return null
 	*/
-	function offsetSet($key, $value) {
+	function offsetSet($key, $value): void {
 		$this->execute();
 		$this->data[$key] = $value;
 	}
@@ -823,14 +823,14 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	* @param string row ID
 	* @return null
 	*/
-	function offsetUnset($key) {
+	function offsetUnset($key): void {
 		$this->execute();
 		unset($this->data[$key]);
 	}
 	
 	// JsonSerializable implementation
 	
-	function jsonSerialize() {
+	function jsonSerialize():JsonSerializable {
 		$this->execute();
 		if ($this->notORM->jsonAsArray) {
 			return array_values($this->data);

--- a/NotORM/Row.php
+++ b/NotORM/Row.php
@@ -128,14 +128,14 @@ class NotORM_Row extends NotORM_Abstract implements IteratorAggregate, ArrayAcce
 	
 	// IteratorAggregate implementation
 	
-	function getIterator() {
+	function getIterator(): IteratorAggregate {
 		$this->access(null);
 		return new ArrayIterator($this->row);
 	}
 	
 	// Countable implementation
 	
-	function count() {
+	function count(): int {
 		return count($this->row);
 	}
 	
@@ -145,7 +145,7 @@ class NotORM_Row extends NotORM_Abstract implements IteratorAggregate, ArrayAcce
 	* @param string column name
 	* @return bool
 	*/
-	function offsetExists($key) {
+	function offsetExists($key): bool {
 		$this->access($key);
 		$return = array_key_exists($key, $this->row);
 		if (!$return) {
@@ -158,7 +158,7 @@ class NotORM_Row extends NotORM_Abstract implements IteratorAggregate, ArrayAcce
 	* @param string column name
 	* @return string
 	*/
-	function offsetGet($key) {
+	function offsetGet($key): string {
 		$this->access($key);
 		if (!array_key_exists($key, $this->row)) {
 			$this->access($key, true);
@@ -170,7 +170,7 @@ class NotORM_Row extends NotORM_Abstract implements IteratorAggregate, ArrayAcce
 	* @param string column name
 	* @return null
 	*/
-	function offsetSet($key, $value) {
+	function offsetSet($key, $value): void {
 		$this->row[$key] = $value;
 		$this->modified[$key] = $value;
 	}
@@ -179,14 +179,14 @@ class NotORM_Row extends NotORM_Abstract implements IteratorAggregate, ArrayAcce
 	* @param string column name
 	* @return null
 	*/
-	function offsetUnset($key) {
+	function offsetUnset($key): void {
 		unset($this->row[$key]);
 		unset($this->modified[$key]);
 	}
 	
 	// JsonSerializable implementation
 	
-	function jsonSerialize() {
+	function jsonSerialize(): JsonSerializable {
 		return $this->row;
 	}
 	

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "vrana/notorm",
+	"name": "trijin/notorm",
 	"description": "NotORM is a PHP library for simple working with data in the database. + with advanced join",
 	"keywords": ["database", "dbal"],
 	"homepage": "http://www.notorm.com/",
@@ -15,6 +15,9 @@
 			"role": "Add `join` comand"
 		}
 	],
+	"replace": {
+		"vrana/notorm": "dev-master"
+	},
 	"autoload": {
 		"files": ["NotORM.php"]
 	}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "vrana/notorm",
-	"description": "NotORM is a PHP library for simple working with data in the database.",
+	"description": "NotORM is a PHP library for simple working with data in the database. + with advanced join",
 	"keywords": ["database", "dbal"],
 	"homepage": "http://www.notorm.com/",
 	"license": ["Apache-2.0", "GPL-2.0+"],
@@ -8,6 +8,11 @@
 		{
 			"name": "Jakub Vrána",
 			"homepage": "http://www.vrana.cz/"
+		}
+		,{
+			"name": "Alex T Trijin",
+			"homepage": "http://trijin.ru/",
+			"role": "Add `join` comand"
 		}
 	],
 	"autoload": {

--- a/readme.txt
+++ b/readme.txt
@@ -20,3 +20,9 @@ foreach ($software->application()->order("title") as $application) { // get all 
     }
 }
 ?>
+
+In this version you can something like this:
+
+$db->books
+   ->select('books.id, books.title, books2.id as id2, books2.title as title2')
+   ->join('books as books2','books.author=books2.author AND books.id!=books2.id');

--- a/readme.txt
+++ b/readme.txt
@@ -20,9 +20,3 @@ foreach ($software->application()->order("title") as $application) { // get all 
     }
 }
 ?>
-
-In this version you can something like this:
-
-$db->books
-   ->select('books.id, books.title, books2.id as id2, books2.title as title2')
-   ->join('books as books2','books.author=books2.author AND books.id!=books2.id');

--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@ PHP 5.1+
 any database supported by PDO (tested with MySQL, SQLite, PostgreSQL, MS SQL, Oracle)
 
 Usage:
+
 <?php
 include "NotORM.php";
 $connection = new PDO("mysql:dbname=software");
@@ -20,3 +21,8 @@ foreach ($software->application()->order("title") as $application) { // get all 
     }
 }
 ?>
+
+In this version you can something like this:
+$db->books
+   ->select('books.id, books.title, books2.id as id2, books2.title as title2')
+   ->join('books as books2','books.author=books2.author AND books.id!=books2.id');


### PR DESCRIPTION
`join` method support alias for table and not simple **ON** statement

```
$db->books
   ->select('books.id, books.title, books2.id as id2, books2.title as title2')
   ->join('books as books2','books.author=books2.author AND books.id!=books2.id');
```
