### PR TITLE
CAND Operator to Conditionally AND Operator in NotORM

### DIFF
--- a/NotORM/Result.php
+++ b/NotORM/Result.php
@@ -477,6 +477,13 @@ class NotORM_Result extends NotORM_Abstract implements Iterator, ArrayAccess, Co
 	function __call($name, array $args) {
 		$operator = strtoupper($name);
 		switch ($operator) {
+			case "CAND":
+				$arg = (is_array($args)) ? $args[count($args) - 1] : 1;
+				if ($arg != "" && $arg != null && $arg != 0) {
+				    return $this->whereOperator("AND", $args);
+				} else {
+				    return $this->whereOperator("AND", array(0 => 1));
+				}
 			case "AND":
 			case "OR":
 				return $this->whereOperator($operator, $args);


### PR DESCRIPTION
CAND Operator is Introduced to Conditionally AND.
eg : 
return $this->db->tbl_table_name()
                        ->cand('field = ?',$arg); 
----------------------------------------
in Above Eg.
$arg = '';
$arg = '0';
This is Helpful to use Select Whole Data From list Where $arg = '0' or $arg = '' or array is Null;
We Can Reduce Code 
Old Method : return $this->db->tbl_table_name()
                        ->and("field = ? or ? = '' or ? = '0' ",$arg); 